### PR TITLE
Fixed non-japanese content layout problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ You can customize the appearance of the furigana text by passing additional para
 
 - **`furiganaLineHeight`**:  
   Line height for the furigana text.  
-  Defaults to `furiganaFontSize * 1.2f` if unspecified.
+  Defaults to `furiganaFontSize` if unspecified.
 
 - **`furiganaLetterSpacing`**:  
   Letter spacing for the furigana text.  

--- a/furiganable/compose-core/src/androidMain/kotlin/com/turtlekazu/furiganable/compose/core/CustomAndroidViewText.kt
+++ b/furiganable/compose-core/src/androidMain/kotlin/com/turtlekazu/furiganable/compose/core/CustomAndroidViewText.kt
@@ -79,7 +79,7 @@ internal fun CustomAndroidViewText(
         color = finalColor,
         lineHeight = if (style.lineHeight.isSpecified) {
             style.lineHeight
-        } else DEFAULT_FONT_SIZE.sp * 1.2f,
+        } else DEFAULT_FONT_SIZE.sp,
         fontSize = if (style.fontSize.isSpecified) {
             style.fontSize
         } else DEFAULT_FONT_SIZE.sp,

--- a/furiganable/compose-core/src/commonMain/kotlin/com/turtlekazu/furiganable/compose/core/TextWithReadingCore.kt
+++ b/furiganable/compose-core/src/commonMain/kotlin/com/turtlekazu/furiganable/compose/core/TextWithReadingCore.kt
@@ -52,7 +52,7 @@ import kotlin.math.max
  * @param furiganaEnabled Whether to enable the furigana. If false, normal text component will be used.
  * @param furiganaGap Space between the main text and the furigana. If unspecified, uses `style.fontSize * 0.03f`.
  * @param furiganaFontSize Font size for the furigana text. If unspecified, `style.fontSize * 0.45f`.
- * @param furiganaLineHeight Line height for the furigana text. If unspecified, uses `furiganaFontSize * 1.2f`.
+ * @param furiganaLineHeight Line height for the furigana text. If unspecified, uses `furiganaFontSize`.
  * @param furiganaLetterSpacing Letter spacing for the furigana text. If unspecified, uses `-style.fontSize * 0.03f`.
  *
  * @param modifier Modifier to apply to the layout.
@@ -140,7 +140,7 @@ fun TextWithReadingCore(
 
         val resolvedFuriganaLineHeight =
             if (furiganaLineHeight.isSpecified) furiganaLineHeight
-            else resolvedFuriganaFontSize * 1.2f
+            else resolvedFuriganaFontSize
 
         val minLineHeight = (
             resolvedFontSize.value +
@@ -174,6 +174,7 @@ fun TextWithReadingCore(
                     ),
                     furiganaGap = resolvedFuriganaGap,
                     furiganaFontSize = resolvedFuriganaFontSize,
+                    furiganaLineHeight = resolvedFuriganaLineHeight,
                     furiganaLetterSpacing = resolvedFuriganaLetterSpacing,
                     fontResolver = fontResolver,
                     density = density,
@@ -214,6 +215,7 @@ private fun calculateAnnotatedString(
     style: TextStyle,
     furiganaGap: TextUnit,
     furiganaFontSize: TextUnit,
+    furiganaLineHeight: TextUnit,
     furiganaLetterSpacing: TextUnit,
     fontResolver: FontFamily.Resolver,
     density: Density,
@@ -303,6 +305,7 @@ private fun calculateAnnotatedString(
                                         style =
                                             style.merge(
                                                 fontSize = furiganaFontSize,
+                                                lineHeight = furiganaLineHeight,
                                                 letterSpacing = furiganaLetterSpacing,
                                             ),
                                     )

--- a/furiganable/compose-core/src/commonMain/kotlin/com/turtlekazu/furiganable/compose/core/TextWithReadingCore.kt
+++ b/furiganable/compose-core/src/commonMain/kotlin/com/turtlekazu/furiganable/compose/core/TextWithReadingCore.kt
@@ -236,7 +236,7 @@ private fun calculateAnnotatedString(
                         Placeholder(
                             width = width,
                             height = height,
-                            placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter,
+                            placeholderVerticalAlign = PlaceholderVerticalAlign.TextTop,
                         ),
                     children = {
                         Box(

--- a/furiganable/compose-core/src/commonMain/kotlin/com/turtlekazu/furiganable/compose/core/TextWithReadingCore.kt
+++ b/furiganable/compose-core/src/commonMain/kotlin/com/turtlekazu/furiganable/compose/core/TextWithReadingCore.kt
@@ -264,7 +264,7 @@ private fun calculateAnnotatedString(
                         Placeholder(
                             width = width,
                             height = height,
-                            placeholderVerticalAlign = PlaceholderVerticalAlign.TextTop,
+                            placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter,
                         ),
                     children = {
                         Box(

--- a/furiganable/compose-core/src/commonMain/kotlin/com/turtlekazu/furiganable/compose/core/TextWithReadingCore.kt
+++ b/furiganable/compose-core/src/commonMain/kotlin/com/turtlekazu/furiganable/compose/core/TextWithReadingCore.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
@@ -277,7 +278,12 @@ private fun calculateAnnotatedString(
                                 modifier = Modifier.wrapContentWidth(unbounded = true),
                                 text = text,
                                 color = style.color,
-                                style = style,
+                                style = style.merge(
+                                    lineHeightStyle = LineHeightStyle(
+                                        alignment = LineHeightStyle.Alignment.Proportional,
+                                        trim = LineHeightStyle.Trim.Both,
+                                    ),
+                                ),
                                 maxLines = 1,
                                 softWrap = false,
                                 overflow = TextOverflow.Visible,
@@ -306,6 +312,10 @@ private fun calculateAnnotatedString(
                                             style.merge(
                                                 fontSize = furiganaFontSize,
                                                 lineHeight = furiganaLineHeight,
+                                                lineHeightStyle = LineHeightStyle(
+                                                    alignment = LineHeightStyle.Alignment.Proportional,
+                                                    trim = LineHeightStyle.Trim.Both,
+                                                ),
                                                 letterSpacing = furiganaLetterSpacing,
                                             ),
                                     )


### PR DESCRIPTION
It used to calculate the text width as font height × character count, which broke when showing English text in variable-width fonts.
By switching to precise width measurement with `TextMeasurer`, this issue is now fixed.