### PR TITLE
Add JVM and Compose Desktop support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This library is heavily inspired by the [android-compose-furigana](https://githu
 
 # Features
 
-- Compatible with Compose Multiplatform (Android, iOS)
+- Compatible with Compose Multiplatform (Android, iOS, Desktop/JVM)
 - Compatible with both Material 2 and Material 3 libraries
 - Easily add furigana by using a simple predefined format, such as `[漢字[かんじ]]`.
 - Supports Localization
@@ -208,6 +208,22 @@ You can customize the appearance of the furigana text by passing additional para
 # Examples
 
 See [demo app code](demoApp/composeApp/src/commonMain/kotlin/com/turtlekazu/furiganable/demo/App.kt) for more examples.
+
+## Run the demo
+
+### Android
+
+Open the project in Android Studio and run the `composeApp` configuration.
+
+### iOS
+
+Open `demoApp/iosApp/iosApp.xcodeproj` in Xcode and run the `iosApp` scheme.
+
+### Desktop
+
+```shell
+./gradlew :demoApp:composeApp:run
+```
 
 # License
 

--- a/demoApp/composeApp/build.gradle.kts
+++ b/demoApp/composeApp/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
 }
 
 kotlin {
+    jvm("desktop")
+
     androidTarget {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
@@ -44,6 +46,9 @@ kotlin {
             implementation(libs.androidx.lifecycle.runtime.compose)
             implementation(project(":furiganable:compose-m2"))
             implementation(project(":furiganable:compose-m3"))
+        }
+        getByName("desktopMain").dependencies {
+            implementation(compose.desktop.currentOs)
         }
     }
 }
@@ -90,4 +95,10 @@ android {
 
 dependencies {
     debugImplementation(compose.uiTooling)
+}
+
+compose.desktop {
+    application {
+        mainClass = "com.turtlekazu.furiganable.demo.MainKt"
+    }
 }

--- a/demoApp/composeApp/src/desktopMain/kotlin/com/turtlekazu/furiganable/demo/Main.kt
+++ b/demoApp/composeApp/src/desktopMain/kotlin/com/turtlekazu/furiganable/demo/Main.kt
@@ -1,0 +1,14 @@
+package com.turtlekazu.furiganable.demo
+
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+
+fun main() =
+    application {
+        Window(
+            onCloseRequest = ::exitApplication,
+            title = "Furiganable",
+        ) {
+            App()
+        }
+    }

--- a/furiganable/compose-core/build.gradle.kts
+++ b/furiganable/compose-core/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
 
 kotlin {
 
+    jvm()
+
     // Target declarations - add or remove as needed below. These define
     // which platforms this KMP module supports.
     // See: https://kotlinlang.org/docs/multiplatform-discover-project.html#targets

--- a/furiganable/compose-core/src/jvmMain/kotlin/com/turtlekazu/furiganable/compose/core/TextSpacingRemoved.jvm.kt
+++ b/furiganable/compose-core/src/jvmMain/kotlin/com/turtlekazu/furiganable/compose/core/TextSpacingRemoved.jvm.kt
@@ -1,0 +1,63 @@
+package com.turtlekazu.furiganable.compose.core
+
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+
+@Composable
+internal actual fun TextSpacingRemoved(
+    text: String,
+    color: Color,
+    style: TextStyle,
+    modifier: Modifier,
+    fontSize: TextUnit,
+    fontStyle: FontStyle?,
+    fontWeight: FontWeight?,
+    fontFamily: FontFamily?,
+    letterSpacing: TextUnit,
+    textDecoration: TextDecoration?,
+    textAlign: TextAlign?,
+    lineHeight: TextUnit,
+    overflow: TextOverflow,
+    softWrap: Boolean,
+    maxLines: Int,
+    minLines: Int,
+    onTextLayout: ((TextLayoutResult) -> Unit)?,
+) {
+    BasicText(
+        text,
+        modifier,
+        style.merge(
+            color = color,
+            fontSize = fontSize,
+            fontWeight = fontWeight,
+            textAlign = textAlign ?: TextAlign.Unspecified,
+            lineHeight = lineHeight,
+            fontFamily = fontFamily,
+            textDecoration = textDecoration,
+            fontStyle = fontStyle,
+            letterSpacing = letterSpacing,
+            lineHeightStyle =
+                LineHeightStyle(
+                    alignment = LineHeightStyle.Alignment.Proportional,
+                    trim = LineHeightStyle.Trim.Both,
+                ),
+        ),
+        onTextLayout,
+        overflow,
+        softWrap,
+        maxLines,
+        minLines,
+    )
+}

--- a/furiganable/compose-m2/build.gradle.kts
+++ b/furiganable/compose-m2/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
 
 kotlin {
 
+    jvm()
+
     // Target declarations - add or remove as needed below. These define
     // which platforms this KMP module supports.
     // See: https://kotlinlang.org/docs/multiplatform-discover-project.html#targets

--- a/furiganable/compose-m3/build.gradle.kts
+++ b/furiganable/compose-m3/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
 
 kotlin {
 
+    jvm()
+
     // Target declarations - add or remove as needed below. These define
     // which platforms this KMP module supports.
     // See: https://kotlinlang.org/docs/multiplatform-discover-project.html#targets


### PR DESCRIPTION
## Summary

- publish JVM variants for `compose-core`, `compose-m2`, and `compose-m3`
- add a JVM implementation of the platform-specific text renderer
- add a Compose Desktop target and entry point to the demo application
- document Android, iOS, and Desktop demo launch paths

## Motivation

Furiganable previously declared only Android and iOS targets, so Compose Desktop projects could not resolve a compatible JVM variant. The shared furigana layout already uses multiplatform Compose APIs; only the JVM target declarations and platform-specific text implementation were missing.

## Impact

Compose Multiplatform applications targeting JVM/Desktop can now consume the library. Existing Android and iOS behavior is unchanged.

## Validation

- compiled the JVM variants for all three library modules
- compiled the Compose Desktop demo
- ran the JVM and Desktop source-set lint checks
- generated the JVM Maven publication POMs
- generated the macOS Desktop distributable
- manually verified furigana rendering in the Desktop demo

Related to #13
